### PR TITLE
package.json wasn't pointing to right 'main' file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "materialize-clockpicker",
   "version": "1.0.1",
   "description": "A materialize clockpicker",
-  "main": "js/materialize.clockpicker.js",
+  "main": "./dist/js/materialize.clockpicker.js",
   "repository": {
     "type": "git",
     "url": "git@github.com:chingyawhao/materialize-clockpicker.git"


### PR DESCRIPTION
Fixed an issue that prevented this npm from working as a nodemodule
because "main" property in package.json was not pointing to correct
file.
